### PR TITLE
Fixed Dockerfiles to allow build on new codebase

### DIFF
--- a/darkstar-db/Dockerfile
+++ b/darkstar-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.5
+FROM mysql:5.6
 
 COPY docker-entrypoint-initdb.d/ docker-entrypoint-initdb.d
 

--- a/darkstar-server/Dockerfile
+++ b/darkstar-server/Dockerfile
@@ -7,12 +7,9 @@ RUN apt-get update && \
   libzmq3-dev autoconf pkg-config software-properties-common python-pip && \
   apt-add-repository -y ppa:ubuntu-toolchain-r/test && \
   apt-get update && \
-  apt-get install -y g++-5 && \
-  cd /usr/bin && \
-  rm gcc g++ cpp && \
-  ln -s gcc-5 gcc && \
-  ln -s g++-5 g++ && \
-  ln -s cpp-5 cpp && \
+  apt-get install -y g++-7 && \
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90 && \
+  apt-get install -y libx32gcc-7-dev && \
   easy_install supervisor && \
   pip install supervisor-stdout && \
   git clone --depth=1 -b ${DS_BRANCH} http://github.com/DarkstarProject/darkstar.git/ /darkstar && \


### PR DESCRIPTION
New SQL files have inserts that need either manually editing or mysql 5.6 and codebase needs g++7 to compile. 